### PR TITLE
GRC 3.7.5 compat: throttle is its own tag now

### DIFF
--- a/grc/gps_nmea_gpsd.xml
+++ b/grc/gps_nmea_gpsd.xml
@@ -3,7 +3,7 @@
 	<name>nmea_gpsd</name>
 	<key>gps_nmea_gpsd</key>
 	<category>gps</category>
-	<flags>throttle</flags>
+	<throttle>1</throttle>
 	<import>import grgps</import>
 	<import>import socket</import>
 	<make>grgps.nmea_gpsd($host, $port, $protocol)</make>

--- a/grc/gps_nmea_serial.xml
+++ b/grc/gps_nmea_serial.xml
@@ -3,7 +3,7 @@
 	<name>nmea_serial</name>
 	<key>gps_nmea_serial</key>
 	<category>grgps</category>
-	<flags>throttle</flags>
+	<throttle>1</throttle>
 	<import>import grgps</import>
 	<make>grgps.nmea_serial($device, $speed)</make>
 	<param>


### PR DESCRIPTION
GRC XML format seems to have changed in a minor way. I've tested that GRC 3.7.5 loads these blocks just fine now.
